### PR TITLE
Updated quality.gradle

### DIFF
--- a/app/config/quality.gradle
+++ b/app/config/quality.gradle
@@ -91,6 +91,7 @@ tasks.create(name: "jacocoUTReport", type: JacocoReport, dependsOn: "test") {
             dir: "${project.buildDir}/intermediates/classes/debug/",
             excludes: ['**/R.class',
                        '**/R$*.class',
+                       '**/*$ViewBinder*.*',
                        '**/*$ViewInjector*.*',
                        '**/BuildConfig.*',
                        '**/Manifest*.*']


### PR DESCRIPTION
jacoco wont compile with 'com.jakewharton:butterknife:7.0.1' unless you exclude this class '*_/_$ViewBinder_._'.
